### PR TITLE
Clean up redundant comments and normalize formatting in mago-terrainer Java sources

### DIFF
--- a/mago-terrainer/src/main/java/com/gaia3d/command/CommandOptions.java
+++ b/mago-terrainer/src/main/java/com/gaia3d/command/CommandOptions.java
@@ -6,14 +6,14 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public enum CommandOptions {
-    /* Default Options */
+    // Default options
     HELP("help", "h", false, "Print Help"),
     QUIET("quiet", "q", false, "Suppress all output except errors"),
     LEAVE_TEMP("leaveTemp", "lt", false, "Leave temporary files for debugging"),
     JSON("json", "j", false, "Generate layer.json from terrain data"),
     CONTINUOUS("continue", "c", false, "Continue from last terrain generation. This option can be used when terrain creation is interrupted or fails."),
 
-    /* Path Options */
+    // Path options
     INPUT("input", "i", true, "[Required] Input directory path"),
     OUTPUT("output", "o", true, "[Required] Output directory path"),
     LOG("log", "l", true, "Log file path"),
@@ -21,7 +21,7 @@ public enum CommandOptions {
     GEOID_PATH("geoid", "g", true, "Set reference height option for terrain data. \n"
             + "Geoid file path for height correction, \n (default: Ellipsoid)(options: Ellipsoid, EGM96 or GeoTIFF File Path)"),
 
-    /* Terrain Generate Options */
+    // Terrain generation options
     MINIMUM_TILE_DEPTH("minDepth", "min", true, "Set minimum terrain tile depth \n(default : 0)(options: 0 - 22)"),
     MAXIMUM_TILE_DEPTH("maxDepth", "max", true, "Set maximum terrain tile depth \n(default : 14)(options: 0 - 22)"),
     INTENSITY("intensity", "is", true, "Set Mesh refinement intensity. \n(default: 4.0)"),
@@ -30,17 +30,17 @@ public enum CommandOptions {
     NODATA_VALUE("nodataValue", "nv", true, "Set NODATA value for terrain generating \n(default : -9999)"),
     EXT_CALCULATE_NORMALS("calculateNormals", "cn", false, "Add terrain octVertexNormals for lighting effect"),
 
-    /* Optimize Options */
+    // Optimization options
     TILING_MOSAIC_SIZE("mosaicSize", "ms", true, "Tiling mosaic buffer size per tile. \n(default : 16)"),
     RASTER_MAXIMUM_SIZE("rasterMaxSize", "mr", true, "Maximum raster size for split function. \n(default : 8192)"),
 
-    /* Experimental Options */
+    // Experimental options
     //INPUT_CRS("inputCrs", "ic", true, "[Experimental] Input Coordinate Reference System, EPSG Code [4326, 3857...]"),
     //TILING_SCHEMA("tilingSchema", "ts", true, "[Experimental] Schema for the terrain data. [geodetic, mercator][default : geodetic]"),
     EXT_META_DATA("metadata", "md", false, "[Experimental] Generate metadata for the terrain data."),
     EXT_WATER_MASK("waterMask", "wm", false, "[Experimental] Generate water mask for the terrain data."),
 
-    /* Debug Options */
+    // Debug options
     DEBUG("debug", "d", false, "[DEBUG] Print more detailed logs.");
 
     private final String longName;

--- a/mago-terrainer/src/main/java/com/gaia3d/command/GlobalOptions.java
+++ b/mago-terrainer/src/main/java/com/gaia3d/command/GlobalOptions.java
@@ -25,11 +25,11 @@ import java.nio.file.StandardCopyOption;
 @Getter
 @Slf4j
 public class GlobalOptions {
-    /* singleton */
+    // Singleton
     private static GlobalOptions instance = new GlobalOptions();
     private CommandLineConfiguration commandLineConfiguration = new DefaultCommandLineConfiguration();
 
-    /* Constants */
+    // Constants
     private static final InterpolationType DEFAULT_INTERPOLATION_TYPE = InterpolationType.BILINEAR;
     private static final int DEFAULT_MINIMUM_TILE_DEPTH = 0;
     private static final int DEFAULT_MAXIMUM_TILE_DEPTH = -1;
@@ -41,14 +41,14 @@ public class GlobalOptions {
     private static final TilingSchema DEFAULT_TILING_SCHEMA = TilingSchema.GEODETIC;
     private static final String DEFAULT_TEMP_DIR = "temp";
 
-    /* Program Information */
+    // Program information
     private String version;
     private String javaVersionInfo;
     private String programInfo;
     private long startTimeMillis = System.currentTimeMillis();
     private long endTimeMillis = 0;
 
-    /* Default Options */
+    // Default options
     private String inputPath;
     private String outputPath;
     private String geoidPath;
@@ -58,7 +58,7 @@ public class GlobalOptions {
     private boolean leaveTemp = false;
     private boolean isContinue = false;
 
-    /* Tiling options */
+    // Tiling options
     private int minimumTileDepth;
     private int maximumTileDepth;
     private InterpolationType interpolationType;
@@ -66,16 +66,16 @@ public class GlobalOptions {
     private double noDataValue;
     private double intensity;
 
-    /* Extensions */
+    // Extensions
     private boolean isCalculateNormalsExtension;
     private boolean isMetaDataExtension;
     private boolean isWaterMaskExtension;
 
-    /* Migration options */
+    // Migration options
     private int mosaicSize;
     private int maxRasterSize;
 
-    /* Temporary paths for processing */
+    // Temporary paths for processing
     private String rootTempPath;
     private String geoidTempPath;
     private String standardizeTempPath;
@@ -185,7 +185,7 @@ public class GlobalOptions {
         instance.setContinue(command.hasOption(CommandOptions.CONTINUOUS.getLongName()));
         instance.setOutputCRS(DEFAULT_TARGET_CRS);
 
-        // TODO : Add support for input CRS and tiling schema options
+        // Reserved for future support of input CRS and tiling schema options.
         instance.setTilingSchema(DEFAULT_TILING_SCHEMA);
 
         if (command.hasOption(CommandOptions.MAXIMUM_TILE_DEPTH.getLongName())) {

--- a/mago-terrainer/src/main/java/com/gaia3d/command/Mago3DTerrainerMain.java
+++ b/mago-terrainer/src/main/java/com/gaia3d/command/Mago3DTerrainerMain.java
@@ -107,18 +107,14 @@ public class Mago3DTerrainerMain {
      * @throws TransformException if a transform error occurs.
      */
     private static void executeCustomTree() throws Exception {
-        //**************************************************************************************************
-        // In custom-tree, the leaf nodes can be in different depths, so we need to handle that accordingly.
-        //**************************************************************************************************
+        // In custom-tree mode, leaf nodes can have different depths.
         GlobalOptions globalOptions = GlobalOptions.getInstance();
 
         TileWgs84Manager tileWgs84Manager = new TileWgs84Manager();
 
-        // New.**********************************************************************************************
         log.info("[Pre][AvailableTileSet] Start calculating available tiles for each depth.");
         tileWgs84Manager.calculateAvailableTilesForEachDepth();
         log.info("[Pre][AvailableTileSet] Finished calculating available tiles for each depth.");
-        // End New.******************************************************************************************
 
         log.info("[Pre][Standardization] Start GeoTiff Standardization files.");
         tileWgs84Manager.processStandardizeRasters();
@@ -146,7 +142,7 @@ public class Mago3DTerrainerMain {
             log.info("[Tile] Finished making tile meshes.");
         } else {
             log.info("[Tile] Start making tile meshes.");
-            tileWgs84Manager.makeTileMeshesCustom(); // New.****************
+            tileWgs84Manager.makeTileMeshesCustom();
             log.info("[Tile] Finished making tile meshes.");
         }
 

--- a/mago-terrainer/src/main/java/com/gaia3d/terrain/structure/TerrainMesh.java
+++ b/mago-terrainer/src/main/java/com/gaia3d/terrain/structure/TerrainMesh.java
@@ -135,9 +135,7 @@ public class TerrainMesh {
     }
 
     public void determineHalfEdgesType() {
-        //***********************************************************************************
-        // Note : function used after loading quantized mesh & convert it to terrain mesh
-        //***********************************************************************************
+        // Used after loading a quantized mesh and converting it to a terrain mesh.
         GaiaRectangle boundingRectangle = getBoundingRectangle();
         double minX = boundingRectangle.getMinX();
         double minY = boundingRectangle.getMinY();

--- a/mago-terrainer/src/main/java/com/gaia3d/terrain/tile/TerrainElevationData.java
+++ b/mago-terrainer/src/main/java/com/gaia3d/terrain/tile/TerrainElevationData.java
@@ -207,7 +207,7 @@ public class TerrainElevationData {
         double value10 = this.getGridValue(columnNext, row);
         double value11 = this.getGridValue(columnNext, rowNext);
 
-        /* check noDataValue */
+        // Ignore noDataValue samples.
         double noDataValue = globalOptions.getNoDataValue();
         boolean hasNoData = (value00 == noDataValue) || (value01 == noDataValue) || (value10 == noDataValue) || (value11 == noDataValue);
         if (hasNoData) {

--- a/mago-terrainer/src/main/java/com/gaia3d/terrain/tile/TerrainElevationDataManager.java
+++ b/mago-terrainer/src/main/java/com/gaia3d/terrain/tile/TerrainElevationDataManager.java
@@ -223,7 +223,7 @@ public class TerrainElevationDataManager {
                 continue;
             }
 
-            /* check if the priority is resolution */
+            // Prioritize by resolution when configured.
             if (priorityType.equals(PriorityType.RESOLUTION)) {
                 double pixelArea = putAndGetGridAreaMap(terrainElevationData.getGeotiffFileName(), terrainElevationData.getGeotiffFilePath());
                 // smaller pixelArea is a higher resolution

--- a/mago-terrainer/src/main/java/com/gaia3d/terrain/tile/TileIndices.java
+++ b/mago-terrainer/src/main/java/com/gaia3d/terrain/tile/TileIndices.java
@@ -31,7 +31,7 @@ public class TileIndices {
 
     private int X = 0;
     private int Y = 0;
-    private int L = 0; // tile depth.
+    private int L = 0;
 
     public void set(int x, int y, int l) {
         X = x;
@@ -39,9 +39,7 @@ public class TileIndices {
         L = l;
     }
 
-    //*************************************************
-    // note : the origin of the tile system is left-up.
-    //*************************************************
+    // The origin of the tile system is left-up.
 
     public void copyFrom(TileIndices tileIndices) {
         X = tileIndices.X;

--- a/mago-terrainer/src/main/java/com/gaia3d/terrain/tile/TileWgs84Manager.java
+++ b/mago-terrainer/src/main/java/com/gaia3d/terrain/tile/TileWgs84Manager.java
@@ -1014,7 +1014,7 @@ public class TileWgs84Manager {
         }
         globalOptions.setInputPath(tempFolder.getAbsolutePath());
 
-        /* check if geoid is provided */
+        // Apply geoid correction only when geoid data is configured.
         String geoidPath = globalOptions.getGeoidPath();
         boolean hasGeoid = geoidPath != null && !geoidPath.isEmpty();
 

--- a/mago-terrainer/src/main/java/com/gaia3d/terrain/tile/geotiff/GaiaGeoTiffManager.java
+++ b/mago-terrainer/src/main/java/com/gaia3d/terrain/tile/geotiff/GaiaGeoTiffManager.java
@@ -69,15 +69,7 @@ public class GaiaGeoTiffManager {
             reader.dispose();
         } catch (Exception e) {
             log.error("Error:", e);
-        } /*finally {
-            if (reader != null) {
-                try {
-                    reader.dispose();
-                } catch (Exception ex) {
-                    log.error("Error:", ex);
-                }
-            }
-        }*/
+        }
 
         // save the coverage
         mapPathGridCoverage2d.put(geoTiffFilePath, coverage);

--- a/mago-terrainer/src/main/java/com/gaia3d/terrain/tile/geotiff/RasterStandardizer.java
+++ b/mago-terrainer/src/main/java/com/gaia3d/terrain/tile/geotiff/RasterStandardizer.java
@@ -38,42 +38,21 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * RasterStandardizer
- * This Class for Standardization data CRS and size.
+ * Standardizes raster CRS and size for terrain processing.
  */
 @Slf4j
 @NoArgsConstructor
 public class RasterStandardizer {
-
-    static {
-        /*JAIExt.registerJAIDescriptor("Warp");
-        JAIExt.registerJAIDescriptor("Affine");
-        JAIExt.registerJAIDescriptor("Rescale");
-        JAIExt.registerJAIDescriptor("Warp/Affine");
-        JAIExt.initJAIEXT();
-
-        JAI jaiInstance = JAI.getDefaultInstance();
-        TileCache tileCache = jaiInstance.getTileCache();
-        tileCache.setMemoryCapacity(1024 * 1024 * 1024);
-        tileCache.setMemoryThreshold(0.75f);
-
-        TileScheduler tileScheduler = jaiInstance.getTileScheduler();
-        // availableProcessors = Runtime.getRuntime().availableProcessors();
-        tileScheduler.setParallelism(Runtime.getRuntime().availableProcessors());
-        tileScheduler.setPriority(Thread.NORM_PRIORITY);*/
-    }
 
     private final GlobalOptions globalOptions = GlobalOptions.getInstance();
 
     public void standardize(GridCoverage2D source, File outputPath) {
         CoordinateReferenceSystem targetCRS = globalOptions.getOutputCRS();
         try {
-            /* split */
             log.info("[Pre][Standardization] Splitting source raster into tiles... {}", outputPath.getName());
             List<RasterInfo> splitTiles = split(source, globalOptions.getMaxRasterSize());
             log.info("[Pre][Standardization] Splitting completed. Total tiles: {}", splitTiles.size());
 
-            /* resampling */
             int total = splitTiles.size();
             AtomicInteger count = new AtomicInteger(0);
             splitTiles.forEach(tile -> {
@@ -113,7 +92,6 @@ public class RasterStandardizer {
             //GridCoverage2D geoidCoverage = readGeoTiff(geoidFile);
             CoordinateReferenceSystem targetCRS = globalOptions.getOutputCRS();
             try {
-                /* split */
                 log.info("[Pre][Standardization][with Geoid] Splitting source raster into tiles... {}", outputPath.getName());
                 List<RasterInfo> splitTiles = split(source, globalOptions.getMaxRasterSize());
                 log.info("[Pre][Standardization][with Geoid] Splitting completed. Total tiles: {}", splitTiles.size());
@@ -121,7 +99,6 @@ public class RasterStandardizer {
                 int total = splitTiles.size();
                 AtomicInteger count = new AtomicInteger(0);
 
-                /* resampling */
                 splitTiles.forEach(tile -> {
                     log.info("[Pre][Standardization][with Geoid][{}/{}] Resampling tile {}", count.incrementAndGet(), total, tile.getName());
 


### PR DESCRIPTION
### Motivation
- Remove decorative and redundant comments (separator stars, `New/End New`, long commented-out blocks) that reduce readability.
- Convert non-Javadoc block comments that duplicate obvious code into concise single-line comments to improve maintainability.
- Preserve and keep concise comments that explain non-trivial behavior (e.g. custom-tree depth handling, geoid handling, no-data rules).

### Description
- Replaced decorative block comments and section block comments with single-line comments in option/config classes (`CommandOptions`, `GlobalOptions`) and normalized phrasing for clarity.
- Removed stale/commented-out initialization and finally blocks (notably the JAI static initializer and a commented `finally` in `GaiaGeoTiffManager`) and cleaned up other commented-out code in raster/geotiff modules (`RasterStandardizer`, `GaiaGeoTiffManager`).
- Simplified and clarified small explanatory comments in tile/mesh classes (`Mago3DTerrainerMain`, `TileIndices`, `TerrainMesh`, `TerrainElevationDataManager`, `TileWgs84Manager`, `TerrainElevationData`) while keeping meaningful logic notes.
- No runtime logic changes were introduced; edits are comment/format-only and small whitespace/phrase adjustments across the terrainer module (multiple Java source files were updated).

### Testing
- Ran a Java compile of the terrainer module with `./gradlew :mago-terrainer:compileJava`, which completed successfully (BUILD SUCCESSFUL) with only compiler warnings related to varargs API usage.
- No unit or integration tests were modified; this change is limited to source comments and formatting.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e8b4a23ac83339eb71e178ec59e8d)